### PR TITLE
feat: Add Linux native dummy runner strategy

### DIFF
--- a/src-linux/Cargo.toml
+++ b/src-linux/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "discord-quest-runner-linux"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/src-linux/src/main.rs
+++ b/src-linux/src/main.rs
@@ -1,0 +1,6 @@
+use std::{thread, time};
+
+fn main() {
+    // Sleep for 1 hour (3600 seconds) to simulate an active game
+    thread::sleep(time::Duration::from_secs(3600));
+}


### PR DESCRIPTION
I noticed in the README that Linux support was blocked because of uncertainty about dependencies (Wine/Proton).

I have verified that Discord on Linux detects games purely by process name (e.g., wwm.exe), just like on Windows. We do not need Wine. We just need a native Linux binary renamed to the target .exe.

I've added src-linux, which contains a minimal Rust "sleeper" binary (similar to src-win).

Verification: I tested this logic on Arch Linux by compiling this binary, renaming it to wwm.exe, and running it. Discord detected "Where Winds Meet" and the quest completed successfully.